### PR TITLE
Adding onlyif so apparmor reload will only happen if parser exists

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,6 +29,7 @@ class openntp::install inherits openntp {
       command     => 'service apparmor reload',
       path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
       refreshonly => true,
+      onlyif      => '/usr/bin/test -d /sbin/apparmor_parser',
       subscribe   => Package['ntp'],
       before      => Package[$openntp::package_name],
     }


### PR DESCRIPTION
onlyif '/sbin/apparmor_parser' exists, I would much appreciate if you could add this to master so we can use librarian-puppet to pull directly from your master, many thanks