### PR TITLE
adding an onlyif to the apparmor exec

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,7 +29,7 @@ class openntp::install inherits openntp {
       command     => 'service apparmor reload',
       path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
       refreshonly => true,
-      onlyif      => '/usr/bin/test -d /sbin/apparmor_parser',
+      onlyif      => '/usr/bin/test -x /sbin/apparmor_parser',
       subscribe   => Package['ntp'],
       before      => Package[$openntp::package_name],
     }


### PR DESCRIPTION
thanks for seeing this Martin, typo exists the "-d" in onlyif is being changed to a "-x", so the apparmor reload will only happen if the /sbin/apparmor_parser exists and is executable
